### PR TITLE
rename tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This server demonstrates how to build a remote MCP server using the Streamable H
 
 - **Tools**:
   - `add`: Addition tool for adding two numbers
-  - `deidentify`: Skyflow deidentification tool for detecting and redacting sensitive information (PII, PHI, etc.)
+  - `dehydrate`: Skyflow dehydration tool for detecting and redacting sensitive information (PII, PHI, etc.)
 - **Resources**:
   - Static `welcome` resource with a welcome message
   - Dynamic `greeting` resource template for personalized greetings
@@ -84,18 +84,18 @@ curl -X POST http://localhost:3000/mcp \
   -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add","arguments":{"a":5,"b":3}},"id":2}'
 ```
 
-### Call the Deidentify Tool
+### Call the Dehydrate Tool
 
-Test calling the `deidentify` tool to redact sensitive information:
+Test calling the `dehydrate` tool to redact sensitive information:
 
 ```bash
 curl -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"deidentify","arguments":{"inputString":"My email is john.doe@example.com and my SSN is 123-45-6789"}},"id":2}'
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"dehydrate","arguments":{"inputString":"My email is john.doe@example.com and my SSN is 123-45-6789"}},"id":2}'
 ```
 
-This will return the deidentified text with sensitive data redacted, along with word and character counts.
+This will return the dehydrated text with sensitive data redacted, along with word and character counts.
 
 ### List Available Resources
 
@@ -141,7 +141,7 @@ To use this MCP server with Claude Desktop, add the following configuration to y
 After updating the config:
 1. Save the file
 2. Restart Claude Desktop completely (quit and reopen)
-3. The `add` and `deidentify` tools should now be available in Claude Desktop
+3. The `add` and `dehydrate` tools should now be available in Claude Desktop
 
 ## Architecture
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ import {
 } from "skyflow-node";
 import crypto from 'crypto';
 
-/** Default maximum wait time for file deidentification operations (in seconds) */
+/** Default maximum wait time for file dehydration operations (in seconds) */
 const DEFAULT_MAX_WAIT_TIME_SECONDS = 64;
 
 /**
@@ -128,7 +128,7 @@ interface DetectedEntityItem {
   extension: string;
 }
 
-/** TypeScript interface for deidentify file output */
+/** TypeScript interface for dehydrate file output */
 interface DeidentifyFileOutput {
   [x: string]: unknown;
   processedFileData?: string;
@@ -171,15 +171,15 @@ const skyflow = new Skyflow({
 });
 
 /**
- * Skyflow Deidentify Tool
+ * Skyflow Dehydrate Tool
  * Replaces sensitive information in text with placeholder tokens
  */
 server.registerTool(
-  "deidentify",
+  "dehydrate",
   {
-    title: "Skyflow Deidentify Tool",
+    title: "Skyflow Dehydrate Tool",
     description:
-      "Deidentify sensitive information in strings using Skyflow. This tool accepts a string and returns another string, but with placeholders for sensitive data. The placeholders tell you what they are replacing. For example, a credit card number might be replaced with [CREDIT_CARD].",
+      "Dehydrate sensitive information in strings using Skyflow. This tool accepts a string and returns another string, but with placeholders for sensitive data. The placeholders tell you what they are replacing. For example, a credit card number might be replaced with [CREDIT_CARD_abc123].",
     inputSchema: { inputString: z.string().min(1) },
     outputSchema: {
       processedText: z.string(),
@@ -212,15 +212,15 @@ server.registerTool(
 );
 
 /**
- * Skyflow Reidentify Tool
- * Restores original sensitive data from deidentified placeholders
+ * Skyflow Rehydrate Tool
+ * Restores original sensitive data from dehydrated placeholders
  */
 server.registerTool(
-  "reidentify",
+  "rehydrate",
   {
-    title: "Skyflow Reidentify Tool",
+    title: "Skyflow Rehydrate Tool",
     description:
-      "Reidentify previously deidentified sensitive information in strings using Skyflow. This tool accepts a string with redacted placeholders (like [CREDIT_CARD]) and returns the original sensitive data.",
+      "Rehydrate previously dehydrated sensitive information in strings using Skyflow. This tool accepts a string with redacted placeholders (like [CREDIT_CARD_abc123]) and returns the original sensitive data.",
     inputSchema: { inputString: z.string().min(1) },
     outputSchema: {
       processedText: z.string(),
@@ -243,16 +243,16 @@ server.registerTool(
 );
 
 /**
- * Skyflow Deidentify File Tool
+ * Skyflow Dehydrate File Tool
  * Processes files to detect and redact sensitive information
  * Maximum file size: 5MB (due to base64 encoding overhead, original binary files should be ~3.75MB or less)
  */
 server.registerTool(
-  "deidentify_file",
+  "dehydrate_file",
   {
-    title: "Skyflow Deidentify File Tool",
+    title: "Skyflow Dehydrate File Tool",
     description:
-      "Deidentify sensitive information in files (images, PDFs, audio, documents) using Skyflow. Accepts base64-encoded file data and returns the processed file with sensitive data redacted or masked. Maximum file size: 5MB (base64-encoded). Due to base64 encoding overhead, original binary files should be approximately 3.75MB or smaller.",
+      "Dehydrate sensitive information in files (images, PDFs, audio, documents) using Skyflow. Accepts base64-encoded file data and returns the processed file with sensitive data redacted or masked. Maximum file size: 5MB (base64-encoded). Due to base64 encoding overhead, original binary files should be approximately 3.75MB or smaller.",
     inputSchema: {
       fileData: z.string().min(1).describe("Base64-encoded file content"),
       fileName: z.string().describe("Original filename for type detection"),


### PR DESCRIPTION
This PR renames the tools from deidentify/reidentify to dehydrate/rehydrate terminology. The changes are purely naming/documentation updates with no functional changes to the code logic.