### PR TITLE
chore(debt): clean up old env names and unused code, update documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,8 +4,6 @@
 
 VAULT_URL=""
 VAULT_ID=""
-WORKSPACE_ID=""
-ACCOUNT_ID=""
 
 # Note: SKYFLOW_API_KEY and REQUIRED_BEARER_TOKEN are no longer used
 # The bearer token is now passed through from the client to Skyflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ curl -X POST "http://localhost:3000/mcp?vaultId={vault_id}&vaultUrl={vault_url}"
 
 **Express HTTP Server** (`src/server.ts`)
 - Serves a single `/mcp` endpoint that handles all MCP protocol requests
-- Accepts query parameters: `accountId`, `vaultId`, `vaultUrl`, `workspaceId`, `apiKey` (optional)
+- Accepts query parameters: `vaultId`, `vaultUrl`, `apiKey` (optional)
 - Uses credentials extraction middleware to validate either Authorization header or apiKey query parameter
 - Configured with 5MB JSON payload limit to support base64-encoded files
 
@@ -130,13 +130,12 @@ This ensures type safety and provides clear error messages for invalid inputs.
 Optional fallback variables in `.env.local`:
 - `VAULT_ID`: Your Skyflow vault identifier (can be overridden via query parameter)
 - `VAULT_URL`: Full vault URL (e.g., `https://ebfc9bee4242.vault.skyflowapis.com`) (can be overridden via query parameter)
-- `WORKSPACE_ID`: Your Skyflow workspace identifier (can be overridden via query parameter)
-- `ACCOUNT_ID`: Your Skyflow account identifier (can be overridden via query parameter)
 - `PORT`: Server port (default: 3000)
 
 **Removed variables** (no longer used):
 - `SKYFLOW_API_KEY`: No longer needed - credentials are passed from client
 - `REQUIRED_BEARER_TOKEN`: No longer needed - all valid credentials are accepted and forwarded to Skyflow
+- `ACCOUNT_ID` / `WORKSPACE_ID`: Never consumed by Skyflow SDK - removed
 
 The server extracts `clusterId` from `vaultUrl` (query parameter or env var) using the pattern: `https://([^.]+).vault`
 
@@ -144,7 +143,7 @@ The server extracts `clusterId` from `vaultUrl` (query parameter or env var) usi
 
 Primary method (bearer token via header):
 ```
-https://your-server.com/mcp?vaultId={vault_id}&vaultUrl={vault_url}&accountId={account_id}&workspaceId={workspace_id}
+https://your-server.com/mcp?vaultId={vault_id}&vaultUrl={vault_url}
 ```
 With header:
 ```
@@ -153,7 +152,7 @@ Authorization: Bearer {your_skyflow_bearer_token}
 
 Fallback method (API key via query parameter):
 ```
-https://your-server.com/mcp?vaultId={vault_id}&vaultUrl={vault_url}&accountId={account_id}&workspaceId={workspace_id}&apiKey={your_skyflow_api_key}
+https://your-server.com/mcp?vaultId={vault_id}&vaultUrl={vault_url}&apiKey={your_skyflow_api_key}
 ```
 
 ## Anonymous Mode

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ A remote MCP server for connecting to a Skyflow Vault for sensitive PII data det
     - [Minimal Example (curl)](#minimal-example-curl)
     - [Client Configuration Checklist](#client-configuration-checklist)
     - [Self-Hosted Fallbacks](#self-hosted-fallbacks)
-    - [Features](#features)
-    - [Configuration File Locations](#configuration-file-locations)
-  - [Architecture](#architecture)
   - [Installation](#installation)
   - [Development](#development)
     - [Quick Start](#quick-start)
@@ -34,8 +31,8 @@ A remote MCP server for connecting to a Skyflow Vault for sensitive PII data det
   - [Integration with Claude Desktop](#integration-with-claude-desktop)
     - [Local Development](#local-development)
     - [Remote Connection (Recommended)](#remote-connection-recommended)
-    - [Configuration File Locations](#configuration-file-locations-1)
-  - [Architecture](#architecture-1)
+    - [Configuration File Locations](#configuration-file-locations)
+  - [Architecture](#architecture)
   - [Dependencies](#dependencies)
   - [Learn More](#learn-more)
 
@@ -97,37 +94,6 @@ See [Integration with Claude Desktop](#integration-with-claude-desktop) for one 
 ### Self-Hosted Fallbacks
 
 When self-hosting, `VAULT_ID` and `VAULT_URL` can be set as environment variables in `.env.local` — query parameters override them per request. Useful for pinning a single vault without rewriting client URLs. See [Environment Variables](#environment-variables).
-
-### Features
-
-- **Tools**:
-  - `de-identify`: Skyflow de-identification tool for detecting and redacting sensitive information (PII, PHI, etc.) in text
-  - `re-identify`: Reverses de-identification by restoring original sensitive data from tokens
-- **Authentication**: Supports both JWT bearer tokens and API keys via `Authorization` header (auto-detected)
-- **Multi-tenant**: Each request can specify different vault configurations via query parameters
-- **Transport**: Streamable HTTP with JSON response support
-- **Port**: Configurable via `PORT` environment variable (defaults to 3000)
-
-**Note**: Make sure the server is running before starting Claude Desktop.
-
-### Configuration File Locations
-
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
-
-After updating the config:
-
-1. Save the file
-2. Restart Claude Desktop completely (quit and reopen)
-3. The `add` and `de-identify` tools should now be available in Claude Desktop
-
-## Architecture
-
-- **Express Server**: Handles HTTP requests on the `/mcp` endpoint
-- **MCP Server**: Registers tools and resources using the official SDK
-- **Streamable HTTP Transport**: Creates a new transport per request to prevent ID collisions
-- **Session Management**: Each request gets its own isolated transport instance
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,17 @@
-# Skyflow PII MCP
+# Skyflow Runtime MCP
 
-A streamable HTTP MCP (Model Context Protocol) server built with TypeScript, Express, and the official MCP SDK.
-
-## Overview
+A remote MCP server for connecting to a Skyflow Vault for sensitive PII data detection,  de-identification, and tokenization as well as selective policy-driven re-identification of sensitive data elements. Give your agent tools to find and remove PII to sanitize text and ensure data privacy and security.
 
 > [!WARNING]  
-> This is an experimental project in development. This project is not supported and offered under an MIT license.
+> This is an experimental project in development. This project is not supported and is offered under an MIT license.
 
-This server demonstrates how to build a remote MCP server using the Streamable HTTP transport. It exposes tools and resources that can be accessed by MCP clients like Claude Desktop.
-
-## Try it out online
-
-This remote MCP server is hosted at `https://pii-mcp.dev/mcp`. You can connect using your own Skyflow credentials - see the configuration section below for details.
-
-### Integration with Claude Desktop
-
-To use this MCP server with Claude Desktop, add the following configuration to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "sky": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://pii-mcp.dev/mcp"],
-      "headers": {
-        "Authorization": "Bearer {mcp token here}"
-      }
-    }
-  }
-}
-```
-
-### Table of contents
-
-- [Skyflow PII MCP](#skyflow-pii-mcp)
-  - [Overview](#overview)
+- [Skyflow Runtime MCP](#skyflow-runtime-mcp)
   - [Try it out online](#try-it-out-online)
-    - [Integration with Claude Desktop](#integration-with-claude-desktop)
-    - [Table of contents](#table-of-contents)
+  - [Connecting in Authenticated Mode](#connecting-in-authenticated-mode)
+    - [Connection Contract](#connection-contract)
+    - [Minimal Example (curl)](#minimal-example-curl)
+    - [Client Configuration Checklist](#client-configuration-checklist)
+    - [Self-Hosted Fallbacks](#self-hosted-fallbacks)
     - [Features](#features)
     - [Configuration File Locations](#configuration-file-locations)
   - [Architecture](#architecture)
@@ -48,16 +22,87 @@ To use this MCP server with Claude Desktop, add the following configuration to y
     - [Manual Setup (Alternative)](#manual-setup-alternative)
     - [Understanding the Ports](#understanding-the-ports)
     - [Environment Variables](#environment-variables)
-    - [Dependencies](#dependencies)
+  - [Anonymous Mode (Try Before You Buy)](#anonymous-mode-try-before-you-buy)
+    - [Quick Start (Anonymous)](#quick-start-anonymous)
+    - [Limitations in Anonymous Mode](#limitations-in-anonymous-mode)
+    - [Claude Desktop (Anonymous)](#claude-desktop-anonymous)
+    - [Server Configuration for Anonymous Mode](#server-configuration-for-anonymous-mode)
+  - [Testing](#testing)
+    - [List Available Tools](#list-available-tools)
+    - [Call the De-identify Tool](#call-the-de-identify-tool)
+    - [Call the Re-identify Tool](#call-the-re-identify-tool)
+  - [Integration with Claude Desktop](#integration-with-claude-desktop)
+    - [Local Development](#local-development)
+    - [Remote Connection (Recommended)](#remote-connection-recommended)
+    - [Configuration File Locations](#configuration-file-locations-1)
+  - [Architecture](#architecture-1)
+  - [Dependencies](#dependencies)
   - [Learn More](#learn-more)
 
+## Try it out online
+
+This remote MCP server is hosted at `https://pii-mcp.dev/mcp`. Connect using your own Skyflow credentials — see [Connecting in Authenticated Mode](#connecting-in-authenticated-mode) for the contract, or [Anonymous Mode](#anonymous-mode-try-before-you-buy) to try it without credentials.
+
+For a concrete client example, see [Integration with Claude Desktop](#integration-with-claude-desktop).
+
+## Connecting in Authenticated Mode
+
+Authenticated mode forwards your own Skyflow credentials to your vault. Any MCP client that supports Streamable HTTP can connect — the server has no client-specific logic.
+
+### Connection Contract
+
+**Endpoint**
+
+```text
+POST https://pii-mcp.dev/mcp?vaultId=<VAULT_ID>&vaultUrl=<VAULT_URL>
+```
+
+**Required query parameters**
+
+| Param | Value | Notes |
+|-------|-------|-------|
+| `vaultId` | Your Skyflow vault ID | Found in Skyflow Studio → Vault details. |
+| `vaultUrl` | Your vault's base URL | e.g. `https://ebfc9bee4242.vault.skyflowapis.com`. URL-encode when embedding in a query string: `https%3A%2F%2Febfc9bee4242.vault.skyflowapis.com`. `clusterId` is extracted from this automatically. |
+
+**Required credential** — pick one:
+
+| Method | Where | Format |
+|--------|-------|--------|
+| Bearer token (preferred) | `Authorization: Bearer <jwt>` header | Skyflow JWT (3 dot-separated base64url segments). Auto-detected. |
+| API key (header) | `Authorization: Bearer <api-key>` header | Any non-JWT value in the `Authorization` header is treated as an API key. |
+| API key (query) | `?apiKey=<api-key>` query parameter | Fallback for clients that can't set headers. Ignored if `Authorization` header is present. |
+
+Credentials are forwarded to Skyflow as-is. The server does not store or log them; Skyflow's API validates them at call time.
+
+### Minimal Example (curl)
+
+```bash
+curl -X POST "https://pii-mcp.dev/mcp?vaultId=$VAULT_ID&vaultUrl=$VAULT_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $SKYFLOW_TOKEN" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+### Client Configuration Checklist
+
+Any MCP client needs to:
+
+1. Point at `/mcp` with `vaultId` + `vaultUrl` appended as query parameters.
+2. Send `Authorization: Bearer <credential>` on every request (or append `&apiKey=<key>` if the client can't inject headers).
+3. Send `Content-Type: application/json` and `Accept: application/json, text/event-stream`.
+
+See [Integration with Claude Desktop](#integration-with-claude-desktop) for one concrete client. The same pattern applies to any Streamable HTTP MCP client (Cursor, MCP Inspector, custom SDK clients).
+
+### Self-Hosted Fallbacks
+
+When self-hosting, `VAULT_ID` and `VAULT_URL` can be set as environment variables in `.env.local` — query parameters override them per request. Useful for pinning a single vault without rewriting client URLs. See [Environment Variables](#environment-variables).
 
 ### Features
 
 - **Tools**:
   - `de-identify`: Skyflow de-identification tool for detecting and redacting sensitive information (PII, PHI, etc.) in text
   - `re-identify`: Reverses de-identification by restoring original sensitive data from tokens
-  - `de-identify_file`: Processes files (images, PDFs, audio, documents) to detect and redact sensitive information
 - **Authentication**: Supports both JWT bearer tokens and API keys via `Authorization` header (auto-detected)
 - **Multi-tenant**: Each request can specify different vault configurations via query parameters
 - **Transport**: Streamable HTTP with JSON response support
@@ -140,20 +185,15 @@ If you prefer to run the inspector and server in separate terminals:
 
 ### Environment Variables
 
-**Authentication Model**: This server supports multiple authentication methods:
-- **JWT bearer token**: Pass via `Authorization: Bearer <jwt>` header - auto-detected by JWT format
-- **API key via header**: Pass via `Authorization: Bearer <api-key>` header - non-JWT values are treated as API keys
-- **API key via query param**: Pass via `?apiKey=<api-key>` query parameter (fallback)
+For authentication methods, see [Connecting in Authenticated Mode](#connecting-in-authenticated-mode).
 
 Create a `.env.local` file with optional fallback values:
 
 - `VAULT_ID`: Your Skyflow vault ID (optional - can be provided via query parameter)
 - `VAULT_URL`: Your Skyflow vault URL (optional - can be provided via query parameter, e.g., `https://ebfc9bee4242.vault.skyflowapis.com`)
-- `WORKSPACE_ID`: Your Skyflow workspace ID (optional - can be provided via query parameter)
-- `ACCOUNT_ID`: Your Skyflow account ID (optional - can be provided via query parameter)
 - `PORT`: Server port (default: 3000)
 
-**Note**: `SKYFLOW_API_KEY` and `REQUIRED_BEARER_TOKEN` are no longer used. The bearer token is now passed through from the client to Skyflow.
+**Note**: `SKYFLOW_API_KEY`, `REQUIRED_BEARER_TOKEN`, `ACCOUNT_ID`, and `WORKSPACE_ID` are no longer used. The bearer token is passed through from the client to Skyflow; account/workspace IDs were never consumed by the SDK.
 
 ## Anonymous Mode (Try Before You Buy)
 
@@ -171,7 +211,7 @@ curl -X POST "https://pii-mcp.dev/mcp" \
 
 ### Limitations in Anonymous Mode
 
-- **Only `de-identify` tool available** - `re-identify` and `de-identify_file` return helpful errors
+- **Only `de-identify` tool available** - `re-identify` returns a helpful error
 - **Tokens use entity counters** - e.g., `[EMAIL_ADDRESS_1]`, `[SSN_2]` instead of vault tokens
 - **Data is NOT persisted** - tokens cannot be re-identified later
 - **Rate limited** - 10 requests per minute per IP (configurable by server operator)
@@ -205,7 +245,7 @@ Server operators can enable anonymous mode by setting these environment variable
 
 ## Testing
 
-**Note**: All requests require authentication and configuration. Replace placeholders with your actual values:
+The examples below use curl. See [Connecting in Authenticated Mode](#connecting-in-authenticated-mode) for the full contract. Placeholders used:
 
 - `{your_bearer_token}`: Your Skyflow JWT bearer token OR API key (auto-detected based on format)
 - `{vault_id}`: Your Skyflow vault ID
@@ -251,7 +291,7 @@ curl -X POST "http://localhost:3000/mcp?vaultId={vault_id}&vaultUrl={vault_url}"
 
 ## Integration with Claude Desktop
 
-To use this MCP server with Claude Desktop, add the following configuration to your `claude_desktop_config.json`:
+Claude Desktop is one concrete client for the [Connection Contract](#connection-contract). It uses `mcp-remote` as a bridge to the Streamable HTTP endpoint. Add the following to your `claude_desktop_config.json`:
 
 ### Local Development
 
@@ -280,7 +320,7 @@ For connecting to the hosted server or any remote instance with dynamic configur
   "mcpServers": {
     "skyflow-pii": {
       "command": "npx",
-      "args": ["mcp-remote", "https://pii-mcp.dev/mcp?accountId={account_id}&vaultId={vault_id}&vaultUrl={vault_url}&workspaceId={workspace_id}"],
+      "args": ["mcp-remote", "https://pii-mcp.dev/mcp?vaultId={vault_id}&vaultUrl={vault_url}"],
       "headers": {
         "Authorization": "Bearer {your_skyflow_bearer_token}"
       }
@@ -291,7 +331,7 @@ For connecting to the hosted server or any remote instance with dynamic configur
 
 **Important Notes**:
 - Replace `{your_skyflow_bearer_token}` with your actual Skyflow bearer token
-- Replace `{account_id}`, `{vault_id}`, `{vault_url}`, and `{workspace_id}` with your Skyflow configuration values
+- Replace `{vault_id}` and `{vault_url}` with your Skyflow configuration values
 - The `vaultUrl` should be URL-encoded (e.g., `https%3A%2F%2Febfc9bee4242.vault.skyflowapis.com`)
 - Make sure the server is running before starting Claude Desktop (for local development)
 
@@ -305,7 +345,7 @@ After updating the config:
 
 1. Save the file
 2. Restart Claude Desktop completely (quit and reopen)
-3. The `de-identify`, `re-identify`, and `de-identify_file` tools should now be available in Claude Desktop
+3. The `de-identify` and `re-identify` tools should now be available in Claude Desktop
 
 ## Architecture
 

--- a/public/index.html
+++ b/public/index.html
@@ -234,13 +234,6 @@
               <h4>re-identify</h4>
               <p>Restore original sensitive data from de-identified tokens</p>
             </div>
-            <div class="tool-card">
-              <h4>de-identify_file</h4>
-              <p>
-                Process files (images, PDFs, audio, documents) to detect and
-                redact sensitive data
-              </p>
-            </div>
           </div>
         </div>
 
@@ -382,14 +375,6 @@
             <li>
               <span class="inline-code">vaultUrl</span> - Your Skyflow vault URL
               (required)
-            </li>
-            <li>
-              <span class="inline-code">accountId</span> - Your Skyflow account
-              ID (optional)
-            </li>
-            <li>
-              <span class="inline-code">workspaceId</span> - Your Skyflow
-              workspace ID (optional)
             </li>
           </ul>
         </div>

--- a/src/lib/validation/vaultConfig.ts
+++ b/src/lib/validation/vaultConfig.ts
@@ -2,8 +2,6 @@ export interface VaultConfig {
   vaultId: string;
   vaultUrl: string;
   clusterId: string;
-  accountId?: string;
-  workspaceId?: string;
 }
 
 export interface ValidationResult {
@@ -80,8 +78,6 @@ export function extractClusterId(vaultUrl: string): string | null {
 export function validateVaultConfig(params: {
   vaultId?: string;
   vaultUrl?: string;
-  accountId?: string;
-  workspaceId?: string;
 }): ValidationResult {
   if (!params.vaultId) {
     return {
@@ -114,8 +110,6 @@ export function validateVaultConfig(params: {
       vaultId: params.vaultId,
       vaultUrl: params.vaultUrl,
       clusterId,
-      accountId: params.accountId,
-      workspaceId: params.workspaceId,
     },
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -234,16 +234,10 @@ app.post("/mcp", authenticateBearer, anonymousRateLimiter, async (req, res) => {
     vaultUrl = (req.query.vaultUrl as string) || process.env.VAULT_URL;
   }
 
-  const accountId = (req.query.accountId as string) || process.env.ACCOUNT_ID;
-  const workspaceId =
-    (req.query.workspaceId as string) || process.env.WORKSPACE_ID;
-
   // Validate vault configuration using extracted validation function
   const validation = validateVaultConfig({
     vaultId,
     vaultUrl,
-    accountId,
-    workspaceId,
   });
 
   if (!validation.isValid) {

--- a/tests/unit/validation/vaultConfig.test.ts
+++ b/tests/unit/validation/vaultConfig.test.ts
@@ -60,8 +60,6 @@ describe("Vault Configuration Validation", () => {
         const result = validateVaultConfig({
           vaultId: "vault123",
           vaultUrl: "https://abc123.vault.skyflowapis.com",
-          accountId: "acc456",
-          workspaceId: "ws789",
         });
 
         expect(result.isValid).toBe(true);
@@ -70,8 +68,6 @@ describe("Vault Configuration Validation", () => {
           vaultId: "vault123",
           vaultUrl: "https://abc123.vault.skyflowapis.com",
           clusterId: "abc123",
-          accountId: "acc456",
-          workspaceId: "ws789",
         });
       });
 
@@ -87,8 +83,6 @@ describe("Vault Configuration Validation", () => {
           vaultId: "vault123",
           vaultUrl: "https://abc123.vault.skyflowapis.com",
           clusterId: "abc123",
-          accountId: undefined,
-          workspaceId: undefined,
         });
       });
 
@@ -104,8 +98,6 @@ describe("Vault Configuration Validation", () => {
           vaultId: "vault123",
           vaultUrl: "abc123.vault.skyflowapis.com",
           clusterId: "abc123",
-          accountId: undefined,
-          workspaceId: undefined,
         });
       });
     });
@@ -199,19 +191,6 @@ describe("Vault Configuration Validation", () => {
 
         expect(result.isValid).toBe(false);
         expect(result.error).toContain("vaultId is required");
-      });
-
-      it("should preserve optional fields when provided", () => {
-        const result = validateVaultConfig({
-          vaultId: "vault123",
-          vaultUrl: "https://abc123.vault.skyflowapis.com",
-          accountId: "account",
-          workspaceId: "workspace",
-        });
-
-        expect(result.isValid).toBe(true);
-        expect(result.config?.accountId).toBe("account");
-        expect(result.config?.workspaceId).toBe("workspace");
       });
     });
   });


### PR DESCRIPTION
This pull request removes all references to the unused `accountId` and `workspaceId` configuration fields throughout the codebase, documentation, environment files, and tests. The only required configuration for Skyflow vault access is now `vaultId` and `vaultUrl`. The changes simplify both user experience and code maintenance, ensuring only relevant and supported parameters are exposed.

**Key changes:**

**API and Configuration Simplification**
- Removed `accountId` and `workspaceId` from all configuration surfaces, including `.env.sample`, `.env.local`, API query parameters, and documentation. Only `vaultId` and `vaultUrl` are now required for connecting to Skyflow. [[1]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL7-L8) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L55-R55) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L133-R146) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L156-R155) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R196) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L283-R323) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L294-R334) [[8]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L237-L246) [[9]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L5-L6) [[10]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L83-L84) [[11]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L117-L118)
- Updated documentation (`README.md`, `CLAUDE.md`, `public/index.html`) to reflect the new, simplified connection contract and environment variables. All examples, instructions, and UI references to `accountId` and `workspaceId` have been removed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-L60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L254-R294) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R348) [[5]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL237-L243) [[6]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL386-L393)

**Code and Type Cleanup**
- Refactored the `VaultConfig` type and related validation logic to eliminate `accountId` and `workspaceId` fields, ensuring type safety and preventing accidental use of unsupported parameters. [[1]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L5-L6) [[2]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L83-L84) [[3]](diffhunk://#diff-69f5f427cf2c428c3d3366990a4cb3fe705a1d59ff70938c641d6819000aa0e4L117-L118) [[4]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L237-L246)

**Test Updates**
- Updated and cleaned up unit tests for vault configuration validation to remove checks and scenarios involving `accountId` and `workspaceId`. [[1]](diffhunk://#diff-eeb02d32f5a864a8de03c80b774e45b8258ab49cd4c2e10ee5064d3768195157L63-L64) [[2]](diffhunk://#diff-eeb02d32f5a864a8de03c80b774e45b8258ab49cd4c2e10ee5064d3768195157L73-L74) [[3]](diffhunk://#diff-eeb02d32f5a864a8de03c80b774e45b8258ab49cd4c2e10ee5064d3768195157L90-L91) [[4]](diffhunk://#diff-eeb02d32f5a864a8de03c80b774e45b8258ab49cd4c2e10ee5064d3768195157L107-L108) [[5]](diffhunk://#diff-eeb02d32f5a864a8de03c80b774e45b8258ab49cd4c2e10ee5064d3768195157L203-L215)

**Feature and UI Consistency**
- Removed references to deprecated or not-yet-implemented tools (such as `de-identify_file`) in documentation and UI, ensuring only supported features (`de-identify` and `re-identify`) are exposed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L174-R214) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R348) [[3]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL237-L243)

These changes streamline the project configuration and documentation, making setup easier for users and reducing maintenance overhead.