### PR TITLE
Add hello/self tool (v0)

### DIFF
--- a/src/lib/tools/hello.ts
+++ b/src/lib/tools/hello.ts
@@ -1,0 +1,34 @@
+import type { ToolResult } from "./types.js";
+
+export interface HelloOutput {
+  message: string;
+  serverName: string;
+  serverVersion: string;
+  vaultId: string;
+  anonymousMode: boolean;
+  timestamp: string;
+}
+
+export interface HelloContext {
+  serverName: string;
+  serverVersion: string;
+  vaultId: string;
+  anonymousMode: boolean;
+}
+
+export async function handleHello(
+  name: string | undefined,
+  context: HelloContext
+): Promise<ToolResult<HelloOutput>> {
+  const greeting = name?.trim() ? `Hello, ${name.trim()}!` : "Hello from Skyflow Runtime MCP!";
+  return {
+    output: {
+      message: greeting,
+      serverName: context.serverName,
+      serverVersion: context.serverVersion,
+      vaultId: context.vaultId,
+      anonymousMode: context.anonymousMode,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { validateVaultConfig, looksLikePlaceholder } from "./lib/validation/vaul
 import { ENTITY_KEYS } from "./lib/mappings/entityMaps.js";
 import { handleDeIdentify } from "./lib/tools/deIdentify.js";
 import { handleReIdentify } from "./lib/tools/reIdentify.js";
+import { handleHello } from "./lib/tools/hello.js";
 import { toStructuredContent } from "./lib/tools/types.js";
 import { authenticateBearer } from "./lib/middleware/authenticateBearer.js";
 import {
@@ -59,10 +60,20 @@ function isAnonymousMode(): boolean {
   return context.isAnonymousMode;
 }
 
+function getCurrentVaultId(): string {
+  const context = requestContextStorage.getStore();
+  if (!context) {
+    throw new Error("No request context available");
+  }
+  return context.vaultId;
+}
+
 // Create an MCP server
+const SERVER_NAME = "Skyflow Runtime MCP Server";
+const SERVER_VERSION = "0.4.0";
 const server = new McpServer({
-  name: "Skyflow Runtime MCP Server",
-  version: "0.4.0",
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
 });
 
 // MCP Apps: Resource URIs
@@ -164,6 +175,43 @@ registerAppTool(
       content: [{ type: "text", text: JSON.stringify(result.output) }],
       structuredContent: toStructuredContent(result.output),
       ...(result.isError && { isError: true }),
+    };
+  }
+);
+
+/**
+ * Hello / self tool
+ * Echoes back basic metadata about the server and the caller's connection.
+ * Useful as a health check and to confirm credentials/vault wiring.
+ */
+server.registerTool(
+  "hello",
+  {
+    title: "Hello / Self",
+    description:
+      "Health check / self endpoint. Returns server name, version, the vault ID this connection is using, whether the session is in anonymous mode, and a timestamp. Pass an optional name to get a personalized greeting.",
+    inputSchema: {
+      name: z.string().optional().describe("Optional name to include in the greeting"),
+    },
+    outputSchema: {
+      message: z.string(),
+      serverName: z.string(),
+      serverVersion: z.string(),
+      vaultId: z.string(),
+      anonymousMode: z.boolean(),
+      timestamp: z.string().describe("ISO-8601 timestamp when the response was generated"),
+    },
+  },
+  async ({ name }) => {
+    const result = await handleHello(name, {
+      serverName: SERVER_NAME,
+      serverVersion: SERVER_VERSION,
+      vaultId: getCurrentVaultId(),
+      anonymousMode: isAnonymousMode(),
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(result.output) }],
+      structuredContent: toStructuredContent(result.output),
     };
   }
 );

--- a/tests/unit/tools/hello.test.ts
+++ b/tests/unit/tools/hello.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { handleHello } from "../../../src/lib/tools/hello";
+
+const baseContext = {
+  serverName: "Test Server",
+  serverVersion: "9.9.9",
+  vaultId: "vault_abc",
+  anonymousMode: false,
+};
+
+describe("handleHello", () => {
+  it("returns a default greeting when no name is provided", async () => {
+    const result = await handleHello(undefined, baseContext);
+    expect(result.isError).toBeUndefined();
+    expect(result.output.message).toBe("Hello from Skyflow Runtime MCP!");
+  });
+
+  it("personalizes the greeting when a name is provided", async () => {
+    const result = await handleHello("Joe", baseContext);
+    expect(result.output.message).toBe("Hello, Joe!");
+  });
+
+  it("treats a blank name as no name", async () => {
+    const result = await handleHello("   ", baseContext);
+    expect(result.output.message).toBe("Hello from Skyflow Runtime MCP!");
+  });
+
+  it("echoes connection metadata", async () => {
+    const result = await handleHello(undefined, {
+      ...baseContext,
+      anonymousMode: true,
+      vaultId: "vault_xyz",
+    });
+    expect(result.output.serverName).toBe("Test Server");
+    expect(result.output.serverVersion).toBe("9.9.9");
+    expect(result.output.vaultId).toBe("vault_xyz");
+    expect(result.output.anonymousMode).toBe(true);
+  });
+
+  it("returns an ISO-8601 timestamp", async () => {
+    const result = await handleHello(undefined, baseContext);
+    expect(() => new Date(result.output.timestamp).toISOString()).not.toThrow();
+    expect(result.output.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a simple `hello` MCP tool that acts as a health/self endpoint
- Returns server name, version, the vault ID the connection is using, anonymous-mode flag, an ISO timestamp, and a greeting (optionally personalized via a `name` arg)
- No UI app in this v0 — registered with the standard SDK `registerTool` so it's text/structured-content only

## Implementation notes
- Handler: `src/lib/tools/hello.ts` — pure function following the existing `ToolResult<T>` pattern, no Skyflow API calls
- Wired in `src/server.ts`; extracted `SERVER_NAME` / `SERVER_VERSION` constants and added a `getCurrentVaultId()` helper alongside the existing `getCurrentSkyflow()` / `isAnonymousMode()` accessors
- Works in both authenticated and anonymous modes (no credential requirements beyond what the `/mcp` endpoint already enforces)

## Test plan
- [x] `pnpm test` — 171 tests pass, including 5 new `handleHello` cases (default greeting, personalized, whitespace-only name, metadata echo, ISO timestamp)
- [x] `pnpm build:server` — clean tsc build
- [ ] Manually invoke `hello` via MCP Inspector to confirm structured output renders in a host


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wsjz61k9wwCq764sUaQ3wx)_